### PR TITLE
Deepen League Buddy: unified team states, audit tab, league hub

### DIFF
--- a/firstballot/components/LeagueBuddy.tsx
+++ b/firstballot/components/LeagueBuddy.tsx
@@ -79,15 +79,13 @@ import {
   calculateTeamTrends,
   calculatePositionStrengths,
   calculateRecentForm,
-  getContenderTier,
-  getTierColor,
   getRankColor,
   getOpponentInfo,
   calculateProjection,
-  buildLineup,
   calculateLeaguePositionRankings,
-  isPlayerAvailable,
+  countRosterPositions,
 } from './league-buddy/utils'
+import { calculateLeaguePlacements } from './league-buddy/competitiveState'
 import { LeagueOverviewSection } from './league-buddy/LeagueOverviewSection'
 import { RosterSection } from './league-buddy/RosterSection'
 import { MatchupView } from './league-buddy/MatchupView'
@@ -97,6 +95,10 @@ import { useLeagueData } from './league-buddy/useLeagueData'
 import { LeagueBuddySidebar } from './league-buddy/LeagueBuddySidebar'
 import { OverviewHeader } from './league-buddy/OverviewHeader'
 import { TradeIntelligencePanel } from './league-buddy/TradeIntelligencePanel'
+import { AuditSection } from './league-buddy/AuditSection'
+import { StatusStrip } from './league-buddy/StatusStrip'
+import { LeagueActivityFeed } from './league-buddy/LeagueActivityFeed'
+import { TrendingPlayersWidget } from './league-buddy/TrendingPlayersWidget'
 
 // Constants for better maintainability
 const GRADE_COLORS = {
@@ -119,9 +121,6 @@ export default function LeagueBuddy({
 }: LeagueBuddyProps) {
   const router = useRouter()
   const [activeSection, setActiveSection] = useState<LeagueSection>('overview')
-  const [lineupMode, setLineupMode] = useState<'current' | 'optimized'>('current')
-  const [whatIfLineup, setWhatIfLineup] = useState<string[]>([])
-  const [selectedStarterToSwap, setSelectedStarterToSwap] = useState<string | null>(null)
 
   const {
     teams,
@@ -136,6 +135,8 @@ export default function LeagueBuddy({
     nflGames,
     allPlayers,
     playerRankings,
+    rosterPositionsRaw,
+    leagueTransactions,
     refetch: fetchLeagueData,
   } = useLeagueData(leagueId, user)
 
@@ -157,6 +158,30 @@ export default function LeagueBuddy({
       return {}
     }
   }, [sortedTeams])
+
+  // Memoized competitive-state placements (Now × Future), computed once per render tree
+  const leaguePlacements = useMemo(() => {
+    try {
+      return calculateLeaguePlacements(teams, !isOffSeason())
+    } catch (error) {
+      console.error('Error calculating league placements:', error)
+      return { placements: {}, nowMedian: 50, futureMedian: 50 }
+    }
+  }, [teams])
+
+  // Roster slot counts (QB/RB/WR/TE/FLEX/SUPER_FLEX), tallied from Sleeper's raw slot array
+  const rosterPositions = useMemo(
+    () => ({
+      QB: 1,
+      RB: 2,
+      WR: 2,
+      TE: 1,
+      FLEX: 1,
+      SUPER_FLEX: 1,
+      ...countRosterPositions(rosterPositionsRaw),
+    }),
+    [rosterPositionsRaw]
+  )
 
   // Memoized event handlers to prevent unnecessary re-renders
   const handleTeamSelect = useCallback((team: TeamData) => {
@@ -510,12 +535,29 @@ export default function LeagueBuddy({
               >
                 League
               </button>
+              <button
+                onClick={() => setActiveSection('audit')}
+                className={`flex-1 px-3 py-2 rounded-md font-mono text-xs font-semibold transition-all ${
+                  activeSection === 'audit'
+                    ? 'bg-yellow-400 text-slate-900'
+                    : 'text-slate-300 hover:text-yellow-400'
+                }`}
+              >
+                Audit
+              </button>
             </div>
           </div>
 
           {/* OVERVIEW SECTION */}
           {activeSection === 'overview' && selectedTeam && leagueOverview && (
             <>
+              <StatusStrip
+                team={selectedTeam}
+                rosterPositions={rosterPositions}
+                currentWeek={currentWeek}
+                onGoToAudit={() => setActiveSection('audit')}
+              />
+
               <OverviewHeader
                 selectedTeam={selectedTeam}
                 sortedTeams={sortedTeams}
@@ -524,6 +566,8 @@ export default function LeagueBuddy({
                 currentWeek={currentWeek}
                 teams={teams}
                 actions={overviewActions}
+                placements={leaguePlacements}
+                leaguePositionRankings={leaguePositionRankings}
               />
 
               {/* Trade Intelligence — Sell High / Hold / Buy Low */}
@@ -534,7 +578,20 @@ export default function LeagueBuddy({
                     Trade Intelligence
                   </h3>
                 </div>
-                <TradeIntelligencePanel players={selectedTeam.players} />
+                <TradeIntelligencePanel
+                  players={selectedTeam.players}
+                  leaguePlayerPool={teams.flatMap((t) => t.players)}
+                />
+              </div>
+
+              {/* League Hub — what's happening across the league */}
+              <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+                <LeagueActivityFeed
+                  transactions={leagueTransactions}
+                  teams={teams}
+                  allPlayers={allPlayers}
+                />
+                <TrendingPlayersWidget trendingPlayers={leagueOverview.trendingPlayers} />
               </div>
 
             </>
@@ -556,12 +613,14 @@ export default function LeagueBuddy({
                       teams={teams}
                       selectedTeam={selectedTeam}
                       leaguePositionRankings={leaguePositionRankings}
+                      placements={leaguePlacements}
                       onTeamSelect={handleTeamSelect}
                     />
                     <PositionRankings
                       teams={teams}
                       selectedTeam={selectedTeam}
                       leaguePositionRankings={leaguePositionRankings}
+                      placements={leaguePlacements}
                       onTeamSelect={handleTeamSelect}
                     />
                   </>
@@ -615,12 +674,14 @@ export default function LeagueBuddy({
                           teams={teams}
                           selectedTeam={selectedTeam}
                           leaguePositionRankings={leaguePositionRankings}
+                          placements={leaguePlacements}
                           onTeamSelect={handleTeamSelect}
                         />
                         <PositionRankings
                           teams={teams}
                           selectedTeam={selectedTeam}
                           leaguePositionRankings={leaguePositionRankings}
+                          placements={leaguePlacements}
                           onTeamSelect={handleTeamSelect}
                         />
                       </>
@@ -629,6 +690,18 @@ export default function LeagueBuddy({
                 )}
               </div>
             </>
+          )}
+
+          {/* AUDIT SECTION */}
+          {activeSection === 'audit' && selectedTeam && (
+            <AuditSection
+              selectedTeam={selectedTeam}
+              teams={teams}
+              rosterPositions={rosterPositions}
+              currentWeek={currentWeek}
+              placement={leaguePlacements.placements[selectedTeam.rosterId]}
+              placements={leaguePlacements}
+            />
           )}
         </div>
       </SidebarInset>

--- a/firstballot/components/league-buddy/ActionPlanPanel.tsx
+++ b/firstballot/components/league-buddy/ActionPlanPanel.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Target } from 'lucide-react'
+import { COMPETITIVE_STATES, type TeamPlacement } from './competitiveState'
+
+interface ActionPlanPanelProps {
+  placement?: TeamPlacement
+}
+
+export function ActionPlanPanel({ placement }: ActionPlanPanelProps) {
+  const stateMeta = placement ? COMPETITIVE_STATES[placement.state] : null
+
+  if (!stateMeta) {
+    return (
+      <div className="bg-card border border-border rounded-lg p-4">
+        <p className="text-sm text-muted-foreground">
+          Not enough roster data to generate a plan yet.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`bg-card border ${stateMeta.border} rounded-lg overflow-hidden`}>
+      <div className={`flex items-center gap-2 px-4 py-3 border-b border-border ${stateMeta.bg}`}>
+        <Target className={`h-4 w-4 ${stateMeta.text}`} />
+        <h3 className={`${stateMeta.text} font-mono text-sm font-bold uppercase`}>
+          {stateMeta.label} Action Plan
+        </h3>
+        <span className="text-xs text-muted-foreground ml-auto italic">{stateMeta.tagline}</span>
+      </div>
+
+      <div className="p-4 space-y-3">
+        <p className="text-sm text-muted-foreground">{stateMeta.description}</p>
+        <ul className="space-y-2">
+          {stateMeta.plan.map((item, idx) => (
+            <li key={idx} className="flex items-start gap-2 text-sm text-foreground">
+              <span className={`mt-1.5 h-1.5 w-1.5 rounded-full ${stateMeta.bg} border ${stateMeta.border} flex-shrink-0`} />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/firstballot/components/league-buddy/AuditSection.tsx
+++ b/firstballot/components/league-buddy/AuditSection.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { StatManagementPanel } from './StatManagementPanel'
+import { ActionPlanPanel } from './ActionPlanPanel'
+import type { RosterPositions } from './utils'
+import type { TeamData } from './types'
+import type { LeaguePlacements, TeamPlacement } from './competitiveState'
+
+interface AuditSectionProps {
+  selectedTeam: TeamData
+  teams: TeamData[]
+  rosterPositions: RosterPositions
+  currentWeek: number
+  placement?: TeamPlacement
+  placements: LeaguePlacements
+}
+
+export function AuditSection({
+  selectedTeam,
+  teams,
+  rosterPositions,
+  currentWeek,
+  placement,
+  placements,
+}: AuditSectionProps) {
+  return (
+    <div className="space-y-4">
+      <StatManagementPanel
+        team={selectedTeam}
+        teams={teams}
+        placements={placements}
+        rosterPositions={rosterPositions}
+        currentWeek={currentWeek}
+      />
+      <ActionPlanPanel placement={placement} />
+    </div>
+  )
+}

--- a/firstballot/components/league-buddy/CompetitiveStateMap.tsx
+++ b/firstballot/components/league-buddy/CompetitiveStateMap.tsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { Compass } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Compass, LayoutGrid, List as ListIcon } from 'lucide-react'
 import {
   COMPETITIVE_STATES,
   type CompetitiveStateKey,
   type LeaguePlacements,
 } from './competitiveState'
 import type { TeamData } from './types'
+
+type SortKey = 'now' | 'future'
 
 // Plot geometry (SVG user units).
 const X0 = 34
@@ -17,13 +20,31 @@ const Y1 = 206 // bottom
 const fx = (now: number) => X0 + (now / 100) * (X1 - X0)
 const fy = (future: number) => Y1 - (future / 100) * (Y1 - Y0)
 
-// Which quadrant label sits in each corner.
-const CORNERS: Array<{ key: CompetitiveStateKey; x: number; y: number; anchor: 'start' | 'end' }> = [
-  { key: 'rebuild', x: X0 + 4, y: Y0 + 11, anchor: 'start' },
-  { key: 'juggernaut', x: X1 - 4, y: Y0 + 11, anchor: 'end' },
-  { key: 'purgatory', x: X0 + 4, y: Y1 - 5, anchor: 'start' },
-  { key: 'contender', x: X1 - 4, y: Y1 - 5, anchor: 'end' },
+function clamp(value: number, min: number, max: number): number {
+  return min <= max ? Math.min(Math.max(value, min), max) : (min + max) / 2
+}
+
+// Which quadrant label sits where. The median divider (mx/my) moves based on the
+// league's actual data, so each label is centered within its own quadrant's real
+// bounds rather than pinned to the plot's absolute corners — otherwise a skewed
+// median leaves labels sitting outside the region they're supposed to name.
+const CORNER_DEFS: Array<{ key: CompetitiveStateKey; vertical: 'top' | 'bottom'; side: 'left' | 'right' }> = [
+  { key: 'rebuild', vertical: 'top', side: 'left' },
+  { key: 'juggernaut', vertical: 'top', side: 'right' },
+  { key: 'purgatory', vertical: 'bottom', side: 'left' },
+  { key: 'contender', vertical: 'bottom', side: 'right' },
 ]
+
+function cornerLayout(mx: number, my: number) {
+  return CORNER_DEFS.map((c) => ({
+    ...c,
+    x:
+      c.side === 'left'
+        ? clamp((X0 + mx) / 2, X0 + 4, mx - 4)
+        : clamp((mx + X1) / 2, mx + 4, X1 - 4),
+    y: c.vertical === 'top' ? Y0 + 11 : Y1 - 5,
+  }))
+}
 
 interface CompetitiveStateMapProps {
   placements: LeaguePlacements
@@ -36,15 +57,25 @@ export function CompetitiveStateMap({
   teams,
   selectedRosterId,
 }: CompetitiveStateMapProps) {
+  const [view, setView] = useState<'map' | 'list'>('list')
+  const [sortKey, setSortKey] = useState<SortKey>('now')
+
+  const teamName = (rosterId: number) =>
+    teams.find((t) => t.rosterId === rosterId)?.teamName ?? ''
+
+  const ranked = useMemo(() => {
+    return Object.values(placements.placements).sort((a, b) =>
+      sortKey === 'now' ? b.nowScore - a.nowScore : b.futureScore - a.futureScore
+    )
+  }, [placements.placements, sortKey])
+
   const selected = placements.placements[selectedRosterId]
   if (!selected) return null
 
   const meta = COMPETITIVE_STATES[selected.state]
   const mx = fx(placements.nowMedian)
   const my = fy(placements.futureMedian)
-
-  const teamName = (rosterId: number) =>
-    teams.find((t) => t.rosterId === rosterId)?.teamName ?? ''
+  const corners = cornerLayout(mx, my)
 
   // Render non-selected dots first, selected last so it sits on top.
   const others = Object.values(placements.placements).filter(
@@ -62,8 +93,95 @@ export function CompetitiveStateMap({
           Franchise Outlook
         </span>
         <span className="text-slate-600 text-[10px]">· relative to league</span>
+
+        <div className="ml-auto flex items-center gap-0.5 rounded-md bg-slate-800/60 p-0.5 border border-slate-700/50">
+          <button
+            type="button"
+            onClick={() => setView('map')}
+            className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] font-mono uppercase transition-colors ${
+              view === 'map' ? 'bg-slate-700 text-slate-100' : 'text-slate-500 hover:text-slate-300'
+            }`}
+          >
+            <LayoutGrid className="h-2.5 w-2.5" /> Map
+          </button>
+          <button
+            type="button"
+            onClick={() => setView('list')}
+            className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] font-mono uppercase transition-colors ${
+              view === 'list' ? 'bg-slate-700 text-slate-100' : 'text-slate-500 hover:text-slate-300'
+            }`}
+          >
+            <ListIcon className="h-2.5 w-2.5" /> List
+          </button>
+        </div>
       </div>
 
+      {view === 'list' ? (
+        <div className="space-y-2">
+          <div className="grid grid-cols-[24px_1fr_auto_auto_auto] gap-2 px-2 text-[9px] font-mono uppercase text-slate-500">
+            <span>#</span>
+            <span>Team</span>
+            <button
+              type="button"
+              onClick={() => setSortKey('now')}
+              className={`text-right hover:text-slate-300 ${sortKey === 'now' ? 'text-slate-300' : ''}`}
+            >
+              Win-Now {sortKey === 'now' ? '▾' : ''}
+            </button>
+            <button
+              type="button"
+              onClick={() => setSortKey('future')}
+              className={`text-right hover:text-slate-300 ${sortKey === 'future' ? 'text-slate-300' : ''}`}
+            >
+              Future {sortKey === 'future' ? '▾' : ''}
+            </button>
+            <span className="text-right">Age</span>
+          </div>
+          <div className="divide-y divide-slate-800">
+            {ranked.map((p, idx) => {
+              const isSelected = p.rosterId === selectedRosterId
+              const rowMeta = COMPETITIVE_STATES[p.state]
+              return (
+                <div
+                  key={p.rosterId}
+                  className={`grid grid-cols-[24px_1fr_auto_auto_auto] items-center gap-2 rounded px-2 py-1.5 ${
+                    isSelected ? 'bg-slate-800/80 ring-1 ring-inset' : ''
+                  }`}
+                  style={isSelected ? { boxShadow: `inset 0 0 0 1px ${rowMeta.accent}66` } : undefined}
+                >
+                  <span className="text-slate-500 text-[10px] font-mono tabular-nums">{idx + 1}</span>
+                  <div className="min-w-0 flex items-center gap-1.5">
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: rowMeta.accent }}
+                    />
+                    <span
+                      className={`text-xs truncate ${isSelected ? 'font-semibold text-slate-100' : 'text-slate-400'}`}
+                    >
+                      {teamName(p.rosterId)}
+                    </span>
+                    <span
+                      className="text-[9px] font-mono uppercase flex-shrink-0"
+                      style={{ color: rowMeta.accent }}
+                    >
+                      {rowMeta.label}
+                    </span>
+                  </div>
+                  <span className="text-slate-300 text-xs font-mono tabular-nums text-right">
+                    {p.nowScore}
+                  </span>
+                  <span className="text-slate-300 text-xs font-mono tabular-nums text-right">
+                    {p.futureScore}
+                  </span>
+                  <span className="text-slate-500 text-[10px] font-mono tabular-nums text-right">
+                    {p.avgAge > 0 ? p.avgAge.toFixed(1) : '—'}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ) : (
       <div className="flex flex-col md:flex-row gap-4 items-center">
         {/* ── Quadrant map ── */}
         <div className="w-full md:w-[58%] flex-shrink-0">
@@ -81,13 +199,13 @@ export function CompetitiveStateMap({
             <line x1={mx} y1={Y0} x2={mx} y2={Y1} stroke="#475569" strokeWidth={1} strokeDasharray="3 3" opacity={0.6} />
             <line x1={X0} y1={my} x2={X1} y2={my} stroke="#475569" strokeWidth={1} strokeDasharray="3 3" opacity={0.6} />
 
-            {/* Corner labels */}
-            {CORNERS.map((c) => (
+            {/* Corner labels — centered within each quadrant's actual (median-split) bounds */}
+            {corners.map((c) => (
               <text
                 key={c.key}
                 x={c.x}
                 y={c.y}
-                textAnchor={c.anchor}
+                textAnchor="middle"
                 className="font-mono"
                 fontSize={7}
                 fill={COMPETITIVE_STATES[c.key].accent}
@@ -164,6 +282,7 @@ export function CompetitiveStateMap({
           </div>
         </div>
       </div>
+      )}
     </div>
   )
 }

--- a/firstballot/components/league-buddy/LeagueActivityFeed.tsx
+++ b/firstballot/components/league-buddy/LeagueActivityFeed.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useMemo } from 'react'
+import { ArrowLeftRight, UserPlus, Gavel, Radio } from 'lucide-react'
+import { buildActivityFeed } from './utils'
+import type { SleeperTransaction, TeamData } from './types'
+
+const TYPE_META: Record<
+  SleeperTransaction['type'],
+  { label: string; icon: typeof ArrowLeftRight; color: string }
+> = {
+  trade: { label: 'Trade', icon: ArrowLeftRight, color: 'text-purple-400' },
+  waiver: { label: 'Waiver', icon: Gavel, color: 'text-blue-400' },
+  free_agent: { label: 'Free Agent', icon: UserPlus, color: 'text-emerald-400' },
+}
+
+function relativeTime(timestamp: number): string {
+  const diffMs = Date.now() - timestamp
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.floor(diffHr / 24)
+  return `${diffDay}d ago`
+}
+
+interface LeagueActivityFeedProps {
+  transactions: SleeperTransaction[]
+  teams: TeamData[]
+  allPlayers: Record<string, any>
+  limit?: number
+}
+
+export function LeagueActivityFeed({
+  transactions,
+  teams,
+  allPlayers,
+  limit = 8,
+}: LeagueActivityFeedProps) {
+  const feed = useMemo(
+    () => buildActivityFeed(transactions, teams, allPlayers).slice(0, limit),
+    [transactions, teams, allPlayers, limit]
+  )
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+        <Radio className="h-4 w-4 text-cyan-400" />
+        <h3 className="text-cyan-400 font-mono text-sm font-bold uppercase">League Activity</h3>
+      </div>
+
+      {feed.length === 0 ? (
+        <div className="text-muted-foreground text-xs text-center py-8">
+          No transactions yet this season.
+        </div>
+      ) : (
+        <div className="divide-y divide-border/40">
+          {feed.map((item) => {
+            const meta = TYPE_META[item.type]
+            const Icon = meta.icon
+            return (
+              <div key={item.id} className="flex items-start gap-3 px-4 py-2.5">
+                <Icon className={`h-3.5 w-3.5 mt-0.5 flex-shrink-0 ${meta.color}`} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className={`text-[10px] font-mono uppercase font-semibold ${meta.color}`}>
+                      {meta.label}
+                    </span>
+                    <span className="text-muted-foreground/60 text-[10px] font-mono">
+                      {relativeTime(item.timestamp)}
+                    </span>
+                  </div>
+                  <div className="text-xs text-foreground space-y-0.5">
+                    {item.adds.map((a, i) => (
+                      <div key={`add-${item.id}-${i}`} className="truncate">
+                        <span className="text-emerald-400 font-mono">+</span> {a.playerName}
+                        <span className="text-muted-foreground"> · {a.teamName}</span>
+                      </div>
+                    ))}
+                    {item.drops.map((d, i) => (
+                      <div key={`drop-${item.id}-${i}`} className="truncate">
+                        <span className="text-red-400 font-mono">−</span> {d.playerName}
+                        <span className="text-muted-foreground"> · {d.teamName}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/firstballot/components/league-buddy/LeagueBuddySidebar.tsx
+++ b/firstballot/components/league-buddy/LeagueBuddySidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion, AnimatePresence } from 'framer-motion'
-import { Users, Trophy, Zap, Calendar, Target, Eye, ChevronDown } from 'lucide-react'
+import { Users, Trophy, Zap, Calendar, Target, Eye, ChevronDown, ClipboardList } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import {
   Sidebar,
@@ -255,6 +255,38 @@ export function LeagueBuddySidebar({
                           >
                             <Trophy className="h-4 w-4" />
                             <span className="font-medium">League</span>
+                          </SidebarMenuButton>
+                        </motion.div>
+                      </SidebarMenuItem>
+                    </motion.div>
+
+                    <motion.div
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      transition={{ delay: 0.18 }}
+                    >
+                      <SidebarMenuItem>
+                        <motion.div
+                          whileHover={{ scale: 1.015, x: 2 }}
+                          whileTap={{ scale: 0.985 }}
+                          transition={{
+                            type: 'spring',
+                            stiffness: 500,
+                            damping: 25,
+                            mass: 0.5,
+                          }}
+                        >
+                          <SidebarMenuButton
+                            onClick={() => setActiveSection('audit')}
+                            isActive={activeSection === 'audit'}
+                            className={`font-mono !px-4 !py-3 !rounded-lg transition-all duration-150 !text-sm ${
+                              activeSection === 'audit'
+                                ? '!bg-yellow-400/15 !text-yellow-400 !border !border-yellow-400/40 !shadow-sm'
+                                : '!text-slate-300 !bg-slate-700/20 !hover:bg-slate-700/40 hover:!text-yellow-400 !border !border-transparent hover:!border-slate-600/50'
+                            }`}
+                          >
+                            <ClipboardList className="h-4 w-4" />
+                            <span className="font-medium">Audit</span>
                           </SidebarMenuButton>
                         </motion.div>
                       </SidebarMenuItem>

--- a/firstballot/components/league-buddy/LeagueStandingsSection.tsx
+++ b/firstballot/components/league-buddy/LeagueStandingsSection.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { TeamData } from './types'
 import { TeamCard } from './TeamCard'
-import { getContenderTier, getTierColor, getRankColor } from './utils'
+import { getRankColor } from './utils'
+import type { LeaguePlacements } from './competitiveState'
 
 interface LeagueStandingsSectionProps {
   teams: TeamData[]
   selectedTeam: TeamData
   leaguePositionRankings: Record<number, Record<string, number>>
+  placements: LeaguePlacements
   onTeamSelect: (team: TeamData) => void
 }
 
@@ -16,6 +18,7 @@ export function LeagueStandingsSection({
   teams,
   selectedTeam,
   leaguePositionRankings,
+  placements,
   onTeamSelect,
 }: LeagueStandingsSectionProps) {
   const sortedTeams = [...teams].sort((a, b) => {
@@ -74,8 +77,7 @@ export function LeagueStandingsSection({
                   isSelected={team.rosterId === selectedTeam.rosterId}
                   onSelect={onTeamSelect}
                   positionRankings={teamRankings}
-                  getContenderTier={getContenderTier}
-                  getTierColor={getTierColor}
+                  placement={placements.placements[team.rosterId]}
                   getRankColor={getRankColor}
                   variant="compact"
                 />

--- a/firstballot/components/league-buddy/OverviewHeader.tsx
+++ b/firstballot/components/league-buddy/OverviewHeader.tsx
@@ -20,7 +20,7 @@ import type {
   TeamData,
 } from './types'
 import { isOffSeason, offSeasonCountdown } from '@/lib/season-utils'
-import { calculateLeaguePlacements, COMPETITIVE_STATES } from './competitiveState'
+import { COMPETITIVE_STATES, type LeaguePlacements } from './competitiveState'
 import { CompetitiveStateMap } from './CompetitiveStateMap'
 
 const GRADE_COLORS = {
@@ -44,6 +44,13 @@ const POSITION_STRENGTH_COLOR = (score: number) => {
   if (score >= 60) return 'bg-yellow-400'
   if (score >= 40) return 'bg-orange-400'
   return 'bg-red-500'
+}
+
+function rankTextColor(rank: number, leagueSize: number): string {
+  if (rank <= 0) return 'text-slate-500'
+  if (rank <= Math.ceil(leagueSize / 4)) return 'text-emerald-400'
+  if (rank <= Math.ceil(leagueSize / 2)) return 'text-yellow-400'
+  return 'text-orange-400'
 }
 
 function getRecentFormIcon(form: string) {
@@ -85,6 +92,8 @@ interface OverviewHeaderProps {
   currentWeek: number
   teams: TeamData[]
   actions: OverviewActions
+  placements: LeaguePlacements
+  leaguePositionRankings?: Record<number, Record<string, number>>
 }
 
 export function OverviewHeader({
@@ -95,6 +104,8 @@ export function OverviewHeader({
   currentWeek,
   teams,
   actions,
+  placements,
+  leaguePositionRankings = {},
 }: OverviewHeaderProps) {
   const userMatchup = currentMatchups.find((m) => m.rosterId === selectedTeam.rosterId)
   const pointDiff = userMatchup ? userMatchup.actualPoints - userMatchup.opponentActualPoints : 0
@@ -123,14 +134,20 @@ export function OverviewHeader({
   // Rank among sorted teams
   const leagueRank = sortedTeams.findIndex((t) => t.rosterId === selectedTeam.rosterId) + 1
 
-  // Competitive-state placements (Now × Future), relative to the league
-  const placements = calculateLeaguePlacements(teams, !isOffSeason())
+  // Competitive-state placement (Now × Future), relative to the league
   const selectedPlacement = placements.placements[selectedTeam.rosterId]
   const stateMeta = selectedPlacement ? COMPETITIVE_STATES[selectedPlacement.state] : null
 
   // Win %
   const totalGames = selectedTeam.wins + selectedTeam.losses
   const winPct = totalGames > 0 ? ((selectedTeam.wins / totalGames) * 100).toFixed(0) : '—'
+
+  // League averages, for "you vs the league" comparisons
+  const avgPointsFor = teams.reduce((sum, t) => sum + t.pointsFor, 0) / (leagueSize || 1)
+  const avgPointsAgainst = teams.reduce((sum, t) => sum + t.pointsAgainst, 0) / (leagueSize || 1)
+  const avgMoves = teams.reduce((sum, t) => sum + t.totalMoves, 0) / (leagueSize || 1)
+
+  const myPositionRanks = leaguePositionRankings[selectedTeam.rosterId] ?? {}
 
   return (
     <Card className="bg-slate-800 border-slate-700 overflow-hidden">
@@ -279,6 +296,35 @@ export function OverviewHeader({
           </div>
         </div>
 
+        {/* You vs. League Average */}
+        <div className="grid grid-cols-3 gap-px bg-slate-700/30 rounded-lg overflow-hidden mb-4">
+          {[
+            { label: 'Points For', value: selectedTeam.pointsFor, avg: avgPointsFor, higherIsBetter: true },
+            { label: 'Points Against', value: selectedTeam.pointsAgainst, avg: avgPointsAgainst, higherIsBetter: false },
+            { label: 'Moves', value: selectedTeam.totalMoves, avg: avgMoves, higherIsBetter: true },
+          ].map(({ label, value, avg, higherIsBetter }) => {
+            const delta = value - avg
+            const isGood = higherIsBetter ? delta >= 0 : delta <= 0
+            return (
+              <div key={label} className="bg-slate-800/80 px-3 py-2">
+                <div className="text-slate-500 text-[9px] font-mono uppercase mb-0.5">{label}</div>
+                <div className="flex items-baseline gap-1.5">
+                  <span className="text-slate-200 text-base font-black font-mono">
+                    {value.toFixed(label === 'Moves' ? 0 : 1)}
+                  </span>
+                  <span className={`text-[9px] font-mono ${isGood ? 'text-emerald-400' : 'text-orange-400'}`}>
+                    {delta >= 0 ? '+' : ''}
+                    {delta.toFixed(1)} vs avg
+                  </span>
+                </div>
+                <div className="text-slate-600 text-[9px] font-mono mt-0.5">
+                  league avg {avg.toFixed(1)}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
         {/* Position strength — compact inline */}
         <div className="bg-slate-900/30 rounded-lg px-4 py-2.5 mb-4 border border-slate-700/30">
           <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
@@ -288,6 +334,7 @@ export function OverviewHeader({
             <div className="flex-1 grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-1.5">
               {(['QB', 'RB', 'WR', 'TE'] as const).map((pos) => {
                 const score = posStrengths?.[pos] ?? 0
+                const rank = myPositionRanks[pos]
                 return (
                   <div key={pos} className="flex items-center gap-2">
                     <span className="text-slate-500 text-[10px] font-mono w-5 flex-shrink-0">{pos}</span>
@@ -298,6 +345,13 @@ export function OverviewHeader({
                       />
                     </div>
                     <span className="text-slate-400 text-[10px] font-mono font-bold w-5 text-right flex-shrink-0">{score}</span>
+                    {rank ? (
+                      <span className={`text-[9px] font-mono font-bold w-7 text-right flex-shrink-0 ${rankTextColor(rank, leagueSize)}`}>
+                        #{rank}
+                      </span>
+                    ) : (
+                      <span className="w-7 flex-shrink-0" />
+                    )}
                   </div>
                 )
               })}

--- a/firstballot/components/league-buddy/PositionRankings.tsx
+++ b/firstballot/components/league-buddy/PositionRankings.tsx
@@ -6,12 +6,14 @@ import { UserAvatar } from '@/components/user-avatar'
 import { Trophy } from 'lucide-react'
 import { TeamCard } from './TeamCard'
 import type { TeamData } from './types'
-import { getContenderTier, getTierColor, getRankColor } from './utils'
+import { getRankColor } from './utils'
+import type { LeaguePlacements } from './competitiveState'
 
 interface PositionRankingsProps {
   teams: TeamData[]
   selectedTeam: TeamData | null
   leaguePositionRankings: Record<number, Record<string, number>>
+  placements: LeaguePlacements
   onTeamSelect: (team: TeamData) => void
 }
 
@@ -19,6 +21,7 @@ export function PositionRankings({
   teams,
   selectedTeam,
   leaguePositionRankings,
+  placements,
   onTeamSelect,
 }: PositionRankingsProps) {
   const sortedTeams = [...teams].sort((a, b) => {
@@ -52,7 +55,7 @@ export function PositionRankings({
                       Team
                     </th>
                     <th className="text-center p-3 text-slate-200 font-mono text-sm min-w-[120px]">
-                      Contender Tier
+                      State
                     </th>
                     <th className="text-center p-3 text-slate-200 font-mono text-sm min-w-[100px]">
                       Starter Rank
@@ -97,8 +100,7 @@ export function PositionRankings({
                           isSelected={selectedTeam?.rosterId === team.rosterId}
                           onSelect={onTeamSelect}
                           positionRankings={teamRankings}
-                          getContenderTier={getContenderTier}
-                          getTierColor={getTierColor}
+                          placement={placements.placements[team.rosterId]}
                           getRankColor={getRankColor}
                           variant="desktop"
                         />
@@ -124,8 +126,7 @@ export function PositionRankings({
                   isSelected={selectedTeam?.rosterId === team.rosterId}
                   onSelect={onTeamSelect}
                   positionRankings={teamRankings}
-                  getContenderTier={getContenderTier}
-                  getTierColor={getTierColor}
+                  placement={placements.placements[team.rosterId]}
                   getRankColor={getRankColor}
                   variant="mobile"
                 />

--- a/firstballot/components/league-buddy/RosterSection.tsx
+++ b/firstballot/components/league-buddy/RosterSection.tsx
@@ -228,11 +228,14 @@ export function RosterSection({ selectedTeam, sortedTeams, teams }: RosterSectio
               variant="outline"
               className="text-[10px] text-muted-foreground border-border ml-auto"
             >
-              Signals based on age/rank — accumulate daily KTC data for trend signals
+              Signals based on production value (P/E) and age — accumulate daily KTC data for trend signals too
             </Badge>
           )}
         </div>
-        <TradeIntelligencePanel players={selectedTeam.players} />
+        <TradeIntelligencePanel
+          players={selectedTeam.players}
+          leaguePlayerPool={teams.flatMap((t) => t.players)}
+        />
       </div>
 
       {/* Roster Scorecard */}

--- a/firstballot/components/league-buddy/StatManagementPanel.tsx
+++ b/firstballot/components/league-buddy/StatManagementPanel.tsx
@@ -1,0 +1,306 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { PlayerHeadshot } from '@/components/ui/player-headshot'
+import { Activity, AlertTriangle, ShieldAlert, Scale, Siren } from 'lucide-react'
+import {
+  calculatePositionDepthGaps,
+  calculateInjuryExposure,
+  calculateTransactionActivity,
+  calculateProductionVsValue,
+  calculateRiskFactor,
+  type RosterPositions,
+} from './utils'
+import type { TeamData } from './types'
+import type { LeaguePlacements } from './competitiveState'
+
+const SIGNAL_STYLE: Record<string, string> = {
+  underperforming: 'text-red-400',
+  overperforming: 'text-yellow-400',
+  aligned: 'text-emerald-400',
+}
+
+const SIGNAL_LABEL: Record<string, string> = {
+  underperforming: 'Underperforming',
+  overperforming: 'Overperforming',
+  aligned: 'Aligned',
+}
+
+const SEVERITY_STYLE: Record<string, string> = {
+  critical: 'bg-red-500/10 text-red-400 border-red-500/40',
+  thin: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/40',
+  healthy: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/40',
+}
+
+const RISK_STYLE: Record<string, string> = {
+  low: 'text-emerald-400',
+  moderate: 'text-yellow-400',
+  high: 'text-red-400',
+}
+
+const ACTIVITY_LABEL: Record<string, string> = {
+  inactive: 'Inactive',
+  moderate: 'Moderate',
+  active: 'Active',
+  hyperactive: 'Hyperactive',
+}
+
+const RISK_STYLE_LABEL: Record<string, string> = {
+  low: 'text-emerald-400',
+  moderate: 'text-yellow-400',
+  high: 'text-red-400',
+}
+
+function healthScoreColor(score: number): string {
+  if (score >= 150) return 'text-emerald-400'
+  if (score >= 100) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+interface StatManagementPanelProps {
+  team: TeamData
+  teams: TeamData[]
+  placements: LeaguePlacements
+  rosterPositions: RosterPositions
+  currentWeek: number
+}
+
+export function StatManagementPanel({
+  team,
+  teams,
+  placements,
+  rosterPositions,
+  currentWeek,
+}: StatManagementPanelProps) {
+  const depthGaps = useMemo(
+    () => calculatePositionDepthGaps(team.players, rosterPositions),
+    [team.players, rosterPositions]
+  )
+  const injuryExposure = useMemo(
+    () => calculateInjuryExposure(team.players, team.starters),
+    [team.players, team.starters]
+  )
+  const activity = useMemo(
+    () => calculateTransactionActivity(team.transactions, currentWeek),
+    [team.transactions, currentWeek]
+  )
+  const byeThisWeek = useMemo(() => team.players.filter((p) => p.isOnBye), [team.players])
+  const productionVsValue = useMemo(
+    () => calculateProductionVsValue(team.rosterId, teams, placements),
+    [team.rosterId, teams, placements]
+  )
+  const risk = useMemo(() => calculateRiskFactor(team, currentWeek), [team, currentWeek])
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+        <Activity className="h-4 w-4 text-orange-400" />
+        <h3 className="text-orange-400 font-mono text-sm font-bold uppercase">Stat Management</h3>
+      </div>
+
+      <div className="p-4 space-y-5">
+        {/* Activity + waiver tiles */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Card className="bg-secondary/10 border-border">
+            <CardContent className="p-3">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                Waiver Position
+              </div>
+              <div className="text-foreground text-xl font-bold font-mono">
+                {team.waiverPosition || '—'}
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-secondary/10 border-border">
+            <CardContent className="p-3">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                Total Moves
+              </div>
+              <div className="text-foreground text-xl font-bold font-mono">
+                {activity.totalMoves}
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-secondary/10 border-border">
+            <CardContent className="p-3">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                Last 4 Weeks
+              </div>
+              <div className="text-foreground text-xl font-bold font-mono">
+                {activity.last4WeeksMoves}
+                <span className="text-muted-foreground text-xs font-normal ml-1">
+                  {ACTIVITY_LABEL[activity.activityLevel]}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-secondary/10 border-border">
+            <CardContent className="p-3">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                On Bye This Week
+              </div>
+              <div className="text-foreground text-xl font-bold font-mono">{byeThisWeek.length}</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Production vs. value */}
+        {productionVsValue && (
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <Scale className={`h-3.5 w-3.5 ${SIGNAL_STYLE[productionVsValue.signal]}`} />
+              <div className="text-[10px] font-mono uppercase text-muted-foreground">
+                Production vs. Value
+              </div>
+              <Badge
+                variant="outline"
+                className={`text-[9px] px-1.5 py-0 border ${SIGNAL_STYLE[productionVsValue.signal]} border-current/40 ml-auto`}
+              >
+                {SIGNAL_LABEL[productionVsValue.signal]}
+              </Badge>
+            </div>
+            <div className="grid grid-cols-2 gap-3 mb-2">
+              <div className="rounded-md border border-border p-3 bg-secondary/10">
+                <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                  Value Rank
+                </div>
+                <div className="text-foreground text-lg font-bold font-mono">
+                  #{productionVsValue.valueRank}
+                </div>
+              </div>
+              <div className="rounded-md border border-border p-3 bg-secondary/10">
+                <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                  Production Rank
+                </div>
+                <div className="text-foreground text-lg font-bold font-mono">
+                  #{productionVsValue.productionRank}
+                </div>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {productionVsValue.signal === 'underperforming' &&
+                "Your roster is more talented than your points scored suggest — talent isn't translating to production yet."}
+              {productionVsValue.signal === 'overperforming' &&
+                'Your points scored are outrunning your roster talent — a strong sign, but watch for regression toward the mean.'}
+              {productionVsValue.signal === 'aligned' &&
+                'Your production matches your roster talent — no red flags here.'}
+            </p>
+          </div>
+        )}
+
+        {/* Position health */}
+        <div>
+          <div className="text-[10px] font-mono uppercase text-muted-foreground mb-2">
+            Position Health
+            <span className="ml-2 normal-case opacity-60">
+              100 = exactly enough available starters
+            </span>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {depthGaps.map((gap) => (
+              <div
+                key={gap.position}
+                className={`rounded-md border p-3 ${SEVERITY_STYLE[gap.severity]}`}
+              >
+                <div className="flex items-baseline justify-between mb-1">
+                  <span className="font-mono text-xs font-bold">{gap.position}</span>
+                  <span
+                    className={`font-mono text-xl font-black tabular-nums ${healthScoreColor(gap.healthScore)}`}
+                  >
+                    {gap.healthScore}
+                  </span>
+                </div>
+                <div className="text-xs font-mono">
+                  {gap.availableCount}/{gap.rosteredCount} available
+                </div>
+                <div className="text-[10px] opacity-70">needs {gap.startersNeeded} to start</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Risk factor */}
+        <div>
+          <div className="flex items-center gap-2 mb-2">
+            <Siren className={`h-3.5 w-3.5 ${RISK_STYLE_LABEL[risk.label]}`} />
+            <div className="text-[10px] font-mono uppercase text-muted-foreground">Risk Factor</div>
+            <Badge
+              variant="outline"
+              className={`text-[9px] px-1.5 py-0 border ${RISK_STYLE_LABEL[risk.label]} border-current/40 ml-auto`}
+            >
+              {risk.label} risk
+            </Badge>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded-md border border-border p-3 bg-secondary/10">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                Overall
+              </div>
+              <div className={`text-2xl font-black font-mono ${RISK_STYLE_LABEL[risk.label]}`}>
+                {risk.score}
+              </div>
+            </div>
+            <div className="rounded-md border border-border p-3 bg-secondary/10">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                Aging Core
+              </div>
+              <div className="text-foreground text-lg font-bold font-mono">
+                {risk.ageRiskScore}
+              </div>
+              <div className="text-muted-foreground/60 text-[9px]">past peak window</div>
+            </div>
+            <div className="rounded-md border border-border p-3 bg-secondary/10">
+              <div className="text-muted-foreground text-[10px] font-mono uppercase mb-1">
+                Injury
+              </div>
+              <div className="text-foreground text-lg font-bold font-mono">
+                {risk.injuryRiskScore}
+              </div>
+              <div className="text-muted-foreground/60 text-[9px]">current + durability</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Injury exposure */}
+        <div>
+          <div className="flex items-center gap-2 mb-2">
+            <ShieldAlert className={`h-3.5 w-3.5 ${RISK_STYLE[injuryExposure.riskLevel]}`} />
+            <div className="text-[10px] font-mono uppercase text-muted-foreground">
+              Injury Exposure
+            </div>
+            <Badge
+              variant="outline"
+              className={`text-[9px] px-1.5 py-0 border ${RISK_STYLE[injuryExposure.riskLevel]} border-current/40 ml-auto`}
+            >
+              {injuryExposure.riskLevel} risk
+            </Badge>
+          </div>
+          {injuryExposure.players.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No injury concerns on this roster.</p>
+          ) : (
+            <div className="space-y-1.5">
+              {injuryExposure.players.map((player) => (
+                <div key={player.playerId} className="flex items-center gap-2">
+                  <PlayerHeadshot
+                    headshotUrl={player.headshot_url}
+                    espnId={player.espn_id}
+                    playerName={player.playerName}
+                    size={24}
+                  />
+                  <span className="text-xs text-foreground flex-1 truncate">{player.playerName}</span>
+                  <span className="text-[10px] text-muted-foreground">{player.position}</span>
+                  <Badge variant="outline" className="text-[9px] px-1.5 py-0 border-orange-500/40 text-orange-400">
+                    <AlertTriangle className="h-2.5 w-2.5 mr-1" />
+                    {player.injury_status || 'Injured'}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/firstballot/components/league-buddy/StatusStrip.tsx
+++ b/firstballot/components/league-buddy/StatusStrip.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useMemo } from 'react'
+import { AlertTriangle, LayersIcon, Siren, CheckCircle2 } from 'lucide-react'
+import {
+  calculateInjuryExposure,
+  calculatePositionDepthGaps,
+  calculateRiskFactor,
+  type RosterPositions,
+} from './utils'
+import type { TeamData } from './types'
+
+interface StatusItem {
+  icon: typeof AlertTriangle
+  color: string
+  text: string
+}
+
+interface StatusStripProps {
+  team: TeamData
+  rosterPositions: RosterPositions
+  currentWeek: number
+  onGoToAudit: () => void
+}
+
+export function StatusStrip({
+  team,
+  rosterPositions,
+  currentWeek,
+  onGoToAudit,
+}: StatusStripProps) {
+  const injuryExposure = useMemo(
+    () => calculateInjuryExposure(team.players, team.starters),
+    [team.players, team.starters]
+  )
+
+  const criticalPositions = useMemo(
+    () =>
+      calculatePositionDepthGaps(team.players, rosterPositions)
+        .filter((g) => g.severity === 'critical')
+        .map((g) => g.position),
+    [team.players, rosterPositions]
+  )
+
+  const risk = useMemo(() => calculateRiskFactor(team, currentWeek), [team, currentWeek])
+
+  const items: StatusItem[] = [
+    injuryExposure.injuredStarterCount > 0 && {
+      icon: AlertTriangle,
+      color: 'text-red-400',
+      text: `${injuryExposure.injuredStarterCount} injured starter${injuryExposure.injuredStarterCount > 1 ? 's' : ''}`,
+    },
+    criticalPositions.length > 0 && {
+      icon: LayersIcon,
+      color: 'text-yellow-400',
+      text: `thin at ${criticalPositions.join(', ')}`,
+    },
+    risk.label === 'high' && {
+      icon: Siren,
+      color: 'text-red-400',
+      text: `high risk roster (${risk.score})`,
+    },
+  ].filter((x): x is StatusItem => Boolean(x))
+
+  if (items.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-2.5 mb-4">
+        <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+        <span className="text-sm text-emerald-400 font-mono">
+          All clear — no action items right now.
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onGoToAudit}
+      className="w-full flex flex-wrap items-center gap-4 rounded-lg border border-yellow-400/30 bg-yellow-400/5 px-4 py-2.5 mb-4 text-left hover:border-yellow-400/50 transition-colors"
+    >
+      <span className="text-[10px] font-mono uppercase text-yellow-400/70 font-semibold flex-shrink-0">
+        Needs Attention
+      </span>
+      {items.map((item, i) => {
+        const Icon = item.icon
+        return (
+          <span key={i} className={`flex items-center gap-1.5 text-sm ${item.color}`}>
+            <Icon className="h-3.5 w-3.5" />
+            {item.text}
+          </span>
+        )
+      })}
+      <span className="text-muted-foreground text-xs ml-auto font-mono">View in Audit →</span>
+    </button>
+  )
+}

--- a/firstballot/components/league-buddy/TeamCard.tsx
+++ b/firstballot/components/league-buddy/TeamCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { UserAvatar } from '@/components/user-avatar'
 import type { TeamData } from './types'
 import { GRADE_COLORS } from './types'
+import { COMPETITIVE_STATES, type TeamPlacement } from './competitiveState'
 
 interface TeamCardProps {
   team: TeamData
@@ -12,8 +13,7 @@ interface TeamCardProps {
   isSelected: boolean
   onSelect: (team: TeamData) => void
   positionRankings?: Record<string, number>
-  getContenderTier: (grade: string, rank: number) => string
-  getTierColor: (tier: string) => string
+  placement?: TeamPlacement
   getRankColor: (rank: number) => string
   variant?: 'mobile' | 'desktop' | 'compact'
 }
@@ -24,12 +24,14 @@ export function TeamCard({
   isSelected,
   onSelect,
   positionRankings = {},
-  getContenderTier,
-  getTierColor,
+  placement,
   getRankColor,
   variant = 'mobile',
 }: TeamCardProps) {
-  const contenderTier = getContenderTier(team.grade || 'F', rank)
+  const stateMeta = placement ? COMPETITIVE_STATES[placement.state] : null
+  const stateBadgeClass = stateMeta
+    ? `${stateMeta.bg} ${stateMeta.text} ${stateMeta.border}`
+    : 'bg-slate-500/10 text-slate-400 border-slate-500/40'
   const qbRank = positionRankings['QB'] || 12
   const rbRank = positionRankings['RB'] || 12
   const wrRank = positionRankings['WR'] || 12
@@ -118,9 +120,9 @@ export function TeamCard({
         <td className="p-3 text-center">
           <Badge
             variant="outline"
-            className={`${getTierColor(contenderTier)} font-mono text-xs px-3 py-1 border`}
+            className={`${stateBadgeClass} font-mono text-xs px-3 py-1 border`}
           >
-            {contenderTier}
+            {stateMeta?.label ?? '—'}
           </Badge>
         </td>
         <td className="p-3 text-center">
@@ -213,9 +215,9 @@ export function TeamCard({
           </div>
           <Badge
             variant="outline"
-            className={`${getTierColor(contenderTier)} font-mono text-xs px-1.5 py-0.5 border flex-shrink-0`}
+            className={`${stateBadgeClass} font-mono text-xs px-1.5 py-0.5 border flex-shrink-0`}
           >
-            {contenderTier}
+            {stateMeta?.label ?? '—'}
           </Badge>
         </div>
 

--- a/firstballot/components/league-buddy/TradeIntelligencePanel.tsx
+++ b/firstballot/components/league-buddy/TradeIntelligencePanel.tsx
@@ -8,9 +8,16 @@ import { Badge } from '@/components/ui/badge'
 import { KtcSparkline } from '@/components/scouting/KtcSparkline'
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
 import type { PlayerData } from './types'
+import {
+  calculatePositionalMedians,
+  calculatePERatio,
+  type PositionalMedians,
+} from './utils'
 
 interface TradeIntelligencePanelProps {
   players: PlayerData[]
+  /** All rostered players league-wide, used to compute positional P/E medians. Falls back to `players` (within-team only) if omitted. */
+  leaguePlayerPool?: PlayerData[]
 }
 
 const POSITION_COLORS: Record<string, string> = {
@@ -44,6 +51,7 @@ interface ClassifiedPlayer {
   signal: 'sell' | 'hold' | 'buy'
   reason: string
   dailyDelta: number // today vs yesterday
+  peRatio: number | null
 }
 
 /** Daily delta: last scraped value minus the one before it */
@@ -53,11 +61,41 @@ function getDailyDelta(player: PlayerData): number {
   return hist[hist.length - 1].value_sf - hist[hist.length - 2].value_sf
 }
 
-function classifyPlayer(player: PlayerData): ClassifiedPlayer {
+const PE_UNDERVALUED = 0.7
+const PE_OVERVALUED = 1.5
+
+function classifyPlayer(
+  player: PlayerData,
+  medians: Record<string, PositionalMedians>
+): ClassifiedPlayer {
   const dailyDelta = getDailyDelta(player)
   const age = player.age ?? 0
   const position = player.position ?? 'WR'
   const { label: dynastyWindow } = getDynastyWindow(age, position)
+  const peRatio = calculatePERatio(player, medians)
+
+  // Primary signal: production vs price, when there's an actual production sample.
+  if (peRatio !== null) {
+    if (peRatio > PE_OVERVALUED) {
+      return {
+        player,
+        signal: 'sell',
+        reason: `P/E ${peRatio.toFixed(2)} · overvalued · ${dynastyWindow}`,
+        dailyDelta,
+        peRatio,
+      }
+    }
+    if (peRatio < PE_UNDERVALUED) {
+      return {
+        player,
+        signal: 'buy',
+        reason: `P/E ${peRatio.toFixed(2)} · undervalued · ${dynastyWindow}`,
+        dailyDelta,
+        peRatio,
+      }
+    }
+    // Fair value on production — fall through to momentum as a tiebreaker.
+  }
 
   // Sell High: biggest daily gainers (value jumped today)
   if (dailyDelta > 50) {
@@ -66,10 +104,12 @@ function classifyPlayer(player: PlayerData): ClassifiedPlayer {
       signal: 'sell',
       reason: `+${dailyDelta.toLocaleString()} today · ${dynastyWindow}`,
       dailyDelta,
+      peRatio,
     }
   }
 
-  // Buy Low: dropped today but young/prime window — buy the dip
+  // Buy Low: dropped today but young/prime window — buy the dip. Also the primary path
+  // for speculative players (rookies etc.) with no production sample yet.
   const isValueDropping = dailyDelta < -50
   const isYoungAndPrime = dynastyWindow === 'Rising' || dynastyWindow === 'Prime'
 
@@ -79,6 +119,7 @@ function classifyPlayer(player: PlayerData): ClassifiedPlayer {
       signal: 'buy',
       reason: `${dailyDelta.toLocaleString()} today · ${dynastyWindow}`,
       dailyDelta,
+      peRatio,
     }
   }
 
@@ -86,8 +127,9 @@ function classifyPlayer(player: PlayerData): ClassifiedPlayer {
   return {
     player,
     signal: 'hold',
-    reason: dynastyWindow,
+    reason: peRatio !== null ? `P/E ${peRatio.toFixed(2)} · fair value` : dynastyWindow,
     dailyDelta,
+    peRatio,
   }
 }
 
@@ -203,14 +245,19 @@ function PlayerRow({ classified, index }: PlayerRowProps) {
   )
 }
 
-export function TradeIntelligencePanel({ players }: TradeIntelligencePanelProps) {
+export function TradeIntelligencePanel({ players, leaguePlayerPool }: TradeIntelligencePanelProps) {
+  const medians = useMemo(
+    () => calculatePositionalMedians(leaguePlayerPool ?? players),
+    [leaguePlayerPool, players]
+  )
+
   const classified = useMemo<ClassifiedPlayer[]>(() => {
     // Only include skill positions
     const skillPlayers = players.filter((p) =>
       ['QB', 'RB', 'WR', 'TE'].includes(p.position)
     )
-    return skillPlayers.map(classifyPlayer)
-  }, [players])
+    return skillPlayers.map((p) => classifyPlayer(p, medians))
+  }, [players, medians])
 
   const sellPlayers = useMemo(
     () =>

--- a/firstballot/components/league-buddy/TrendingPlayersWidget.tsx
+++ b/firstballot/components/league-buddy/TrendingPlayersWidget.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Flame, TrendingUp } from 'lucide-react'
+import type { TrendingPlayer } from './types'
+
+const POSITION_BADGE: Record<string, string> = {
+  QB: 'bg-blue-500/20 text-blue-400 border-blue-500/40',
+  RB: 'bg-green-500/20 text-green-400 border-green-500/40',
+  WR: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/40',
+  TE: 'bg-purple-500/20 text-purple-400 border-purple-500/40',
+  K: 'bg-pink-500/20 text-pink-400 border-pink-500/40',
+  DEF: 'bg-gray-500/20 text-gray-400 border-gray-500/40',
+}
+
+interface TrendingPlayersWidgetProps {
+  trendingPlayers: TrendingPlayer[]
+  limit?: number
+}
+
+export function TrendingPlayersWidget({ trendingPlayers, limit = 6 }: TrendingPlayersWidgetProps) {
+  const topAdds = useMemo(
+    () =>
+      [...trendingPlayers]
+        .sort((a, b) => b.addCount - a.addCount)
+        .slice(0, limit),
+    [trendingPlayers, limit]
+  )
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+        <Flame className="h-4 w-4 text-red-400" />
+        <h3 className="text-red-400 font-mono text-sm font-bold uppercase">Trending Adds</h3>
+        <span className="text-muted-foreground/60 text-[10px] font-mono ml-auto">league-wide</span>
+      </div>
+
+      {topAdds.length === 0 ? (
+        <div className="text-muted-foreground text-xs text-center py-8">
+          No trending player data available.
+        </div>
+      ) : (
+        <div className="divide-y divide-border/40">
+          {topAdds.map((p) => (
+            <div key={p.playerId} className="flex items-center gap-2 px-4 py-2">
+              <Badge
+                variant="outline"
+                className={`text-[10px] px-1.5 py-0 border font-mono ${POSITION_BADGE[p.position] ?? 'bg-slate-500/20 text-slate-400 border-slate-500/40'}`}
+              >
+                {p.position}
+              </Badge>
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-semibold text-foreground truncate">{p.playerName}</div>
+                <div className="text-[10px] text-muted-foreground">{p.team}</div>
+              </div>
+              <div className="flex items-center gap-1 text-emerald-400 flex-shrink-0">
+                <TrendingUp className="h-3 w-3" />
+                <span className="text-xs font-mono font-bold tabular-nums">{p.addCount}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/firstballot/components/league-buddy/competitiveState.ts
+++ b/firstballot/components/league-buddy/competitiveState.ts
@@ -36,6 +36,7 @@ export interface CompetitiveStateMeta {
   text: string // tailwind text color
   border: string // tailwind border color
   bg: string // tailwind background tint
+  plan: string[] // recommended actions for a team in this state
 }
 
 export const COMPETITIVE_STATES: Record<CompetitiveStateKey, CompetitiveStateMeta> = {
@@ -48,6 +49,12 @@ export const COMPETITIVE_STATES: Record<CompetitiveStateKey, CompetitiveStateMet
     text: 'text-yellow-400',
     border: 'border-yellow-400/40',
     bg: 'bg-yellow-400/10',
+    plan: [
+      'Press the advantage — target other contenders\' aging vets while your window is wide open',
+      'Avoid trading future picks away; you don\'t need to mortgage the future to win now',
+      'Use your depth as trade capital to plug the one or two weakest starting spots',
+      'Don\'t get complacent on the waiver wire — marginal upgrades compound over a long window',
+    ],
   },
   contender: {
     key: 'contender',
@@ -58,36 +65,60 @@ export const COMPETITIVE_STATES: Record<CompetitiveStateKey, CompetitiveStateMet
     text: 'text-blue-400',
     border: 'border-blue-400/40',
     bg: 'bg-blue-400/10',
+    plan: [
+      'Sell future picks for proven win-now production — your aging core has a shrinking shelf life',
+      'Target rebuilding teams\' aging starters at a discount before their value cliff hits',
+      'Prioritize depth at your thinnest starting position over speculative youth',
+      'Don\'t hoard rookie picks you won\'t be competitive enough to use',
+    ],
   },
   'house-money': {
     key: 'house-money',
-    label: 'House Money',
+    label: 'Pretender',
     tagline: 'Punching above your roster',
     description: 'Your record is outrunning your roster value. Everything from here is a bonus — sell high or ride it.',
     accent: '#c084fc',
     text: 'text-purple-400',
     border: 'border-purple-400/40',
     bg: 'bg-purple-400/10',
+    plan: [
+      'Sell high on any player whose value has spiked past what their long-term outlook supports',
+      'Be honest about roster construction — a good record can mask real depth problems',
+      'Target future picks in trades rather than more short-term rentals',
+      'Don\'t buy into your own hype — bolster the roster like a team that expects to regress',
+    ],
   },
   rebuild: {
     key: 'rebuild',
-    label: 'Rebuild',
+    label: 'Rebuilder',
     tagline: 'Young and ascending',
     description: 'Light on win-now value but rich in youth. Stockpile picks, develop, and time the leap.',
     accent: '#22d3ee',
     text: 'text-cyan-400',
     border: 'border-cyan-400/40',
     bg: 'bg-cyan-400/10',
+    plan: [
+      'Trade aging win-now vets to contenders while their value is still high',
+      'Stockpile future draft picks — they\'re your cheapest path to more young assets',
+      'Be patient with your young core; don\'t panic-trade after a slow start',
+      'Avoid overpaying for short-term rentals that don\'t extend your competitive window',
+    ],
   },
   purgatory: {
     key: 'purgatory',
-    label: 'Purgatory',
+    label: 'Fringe Team',
     tagline: 'Stuck in the middle',
     description: 'Not strong enough to contend, not young enough to rebuild. Pick a direction and commit.',
     accent: '#f87171',
     text: 'text-red-400',
     border: 'border-red-400/40',
     bg: 'bg-red-400/10',
+    plan: [
+      'Pick a direction — half-measures keep you stuck here longest',
+      'Audit your core\'s remaining window; if it\'s under 2 years, lean toward rebuilding',
+      'Sell aging assets before they decline further, even at a discount',
+      'Avoid speculative "sidegrade" trades that don\'t clearly push you toward contending or rebuilding',
+    ],
   },
 }
 

--- a/firstballot/components/league-buddy/types.ts
+++ b/firstballot/components/league-buddy/types.ts
@@ -10,7 +10,7 @@ export interface LeagueBuddyProps {
   onLeagueChange?: (leagueId: string) => void
 }
 
-export type LeagueSection = 'overview' | 'roster' | 'league'
+export type LeagueSection = 'overview' | 'roster' | 'league' | 'audit'
 
 export interface PlayerRankingSummary {
   rank: number

--- a/firstballot/components/league-buddy/useLeagueData.ts
+++ b/firstballot/components/league-buddy/useLeagueData.ts
@@ -20,6 +20,7 @@ import {
   calculatePositionStrengths,
   calculateRecentForm,
   getOpponentInfo,
+  countRosterPositions,
 } from './utils'
 
 interface UseLeagueDataReturn {
@@ -35,6 +36,8 @@ interface UseLeagueDataReturn {
   nflGames: Record<string, { opponent: string; isHome: boolean }>
   allPlayers: Record<string, any>
   playerRankings: Record<string, any>
+  rosterPositionsRaw: string[]
+  leagueTransactions: SleeperTransaction[]
   refetch: () => Promise<void>
 }
 
@@ -87,6 +90,8 @@ interface LeagueDataBundle {
   allPlayers: Record<string, any>
   playerRankings: Record<string, any>
   defaultSelectedRosterId: number | null
+  rosterPositionsRaw: string[]
+  leagueTransactions: SleeperTransaction[]
 }
 
 function getUserId(user: unknown): string | undefined {
@@ -515,6 +520,7 @@ async function fetchLeagueDataBundle(leagueId: string, user?: unknown): Promise<
     // Non-fatal
       }
 
+      let leagueTransactions: SleeperTransaction[] = []
       try {
     const weekNums = Array.from({ length: week }, (_, i) => i + 1)
         const txResults = await Promise.all(
@@ -533,6 +539,8 @@ async function fetchLeagueDataBundle(leagueId: string, user?: unknown): Promise<
     teamsData.forEach((team) => {
       team.transactions = allTx.filter((tx) => tx.roster_ids.includes(team.rosterId))
         })
+
+        leagueTransactions = [...allTx].sort((a, b) => b.created - a.created)
       } catch {
     // Non-fatal
   }
@@ -580,13 +588,14 @@ async function fetchLeagueDataBundle(leagueId: string, user?: unknown): Promise<
         lowestOwner?.first_name ||
         `Team ${lowestScoring?.roster_id || 'Unknown'}`,
       trendingPlayers,
-      rosterPositions: league?.roster_positions || {
+      rosterPositions: {
         QB: 1,
         RB: 2,
         WR: 2,
         TE: 1,
         FLEX: 1,
         SUPER_FLEX: 1,
+        ...countRosterPositions(league?.roster_positions),
       },
     },
     currentMatchups: matchupData,
@@ -596,6 +605,8 @@ async function fetchLeagueDataBundle(leagueId: string, user?: unknown): Promise<
     allPlayers: enhancedPlayers,
     playerRankings: rankingsMap,
     defaultSelectedRosterId: userRoster?.roster_id || teamsData[0]?.rosterId || null,
+    rosterPositionsRaw: Array.isArray(league?.roster_positions) ? league.roster_positions : [],
+    leagueTransactions,
   }
 }
 
@@ -616,6 +627,8 @@ export function useLeagueData(leagueId: string, user?: unknown): UseLeagueDataRe
   const nflGames = data?.nflGames ?? {}
   const allPlayers = data?.allPlayers ?? {}
   const playerRankings = data?.playerRankings ?? {}
+  const rosterPositionsRaw = data?.rosterPositionsRaw ?? []
+  const leagueTransactions = data?.leagueTransactions ?? []
 
   const selectedTeam = useMemo(() => {
     if (teams.length === 0) return null
@@ -647,6 +660,8 @@ export function useLeagueData(leagueId: string, user?: unknown): UseLeagueDataRe
     nflGames,
     allPlayers,
     playerRankings,
+    rosterPositionsRaw,
+    leagueTransactions,
     refetch,
   }
 }

--- a/firstballot/components/league-buddy/utils.ts
+++ b/firstballot/components/league-buddy/utils.ts
@@ -1,5 +1,6 @@
 // Utility functions for LeagueBuddy component
-import type { PlayerData, TeamTrends, PositionStrengths, TeamData } from './types'
+import type { PlayerData, TeamTrends, PositionStrengths, TeamData, SleeperTransaction } from './types'
+import type { LeaguePlacements } from './competitiveState'
 
 // Utility functions for data validation and processing
 export const validateApiResponse = (response: Response, endpoint: string): boolean => {
@@ -180,29 +181,7 @@ export const calculateRecentForm = (roster: any, matchups: any[]): string => {
   return 'Very Cold'
 }
 
-// Helper functions for tier and color calculations
-export const getContenderTier = (grade: string, rank: number): string => {
-  if (['A+', 'A'].includes(grade) && rank <= 2) return 'Powerhouse'
-  if (['A-', 'B+', 'B'].includes(grade) && rank <= 6) return 'Contender'
-  if (['B-', 'C+', 'C'].includes(grade) && rank <= 10) return 'Pretender'
-  return 'Rebuilder'
-}
-
-export const getTierColor = (tier: string): string => {
-  switch (tier) {
-    case 'Powerhouse':
-      return 'bg-green-900/80 text-green-200 border-green-700/50'
-    case 'Contender':
-      return 'bg-yellow-900/80 text-yellow-200 border-yellow-700/50'
-    case 'Pretender':
-      return 'bg-orange-900/80 text-orange-200 border-orange-700/50'
-    case 'Rebuilder':
-      return 'bg-red-900/80 text-red-200 border-red-700/50'
-    default:
-      return 'bg-gray-900/80 text-gray-200 border-gray-700/50'
-  }
-}
-
+// Helper function for rank color calculations
 export const getRankColor = (rank: number): string => {
   if (rank <= 3) return 'bg-green-900/70 text-green-100 border-green-700/40'
   if (rank <= 6) return 'bg-yellow-900/70 text-yellow-100 border-yellow-700/40'
@@ -383,6 +362,26 @@ export interface RosterPositions {
   SUPER_FLEX?: number
 }
 
+/**
+ * Sleeper's roster_positions is a flat slot array (e.g. ['QB','RB','RB','WR','WR','TE',
+ * 'FLEX','SUPER_FLEX','BN','BN',...]), not a position->count map. Tally it into counts,
+ * ignoring bench/IR/taxi slots and any position buildLineup doesn't fill (K, DEF, etc).
+ */
+export const countRosterPositions = (positions: string[] | undefined): RosterPositions => {
+  // Empty/missing input means "unknown" — return {} so callers can fall back to sane
+  // defaults instead of zeroing out every slot.
+  if (!Array.isArray(positions) || positions.length === 0) return {}
+
+  const counts: RosterPositions = { QB: 0, RB: 0, WR: 0, TE: 0, FLEX: 0, SUPER_FLEX: 0 }
+  const ignored = new Set(['BN', 'IR', 'TAXI'])
+  for (const slot of positions) {
+    const key = slot?.toUpperCase()
+    if (!key || ignored.has(key) || !(key in counts)) continue
+    counts[key as keyof RosterPositions] = (counts[key as keyof RosterPositions] ?? 0) + 1
+  }
+  return counts
+}
+
 // Helper function to check if player should be excluded from optimized lineup
 export const isPlayerAvailable = (player: PlayerData): boolean => {
   // Exclude injured players - specifically IR and Doubtful statuses
@@ -404,6 +403,19 @@ export const isPlayerAvailable = (player: PlayerData): boolean => {
 
   // Player is available if not injured and not on bye
   return !isInjured && !isBye
+}
+
+/**
+ * Prefer fantasy_ppg (points per game) when available — a more realistic proxy for
+ * "who should start" than static rank. Falls back to rank when ppg data is missing,
+ * and prefers a player with ppg data over one without regardless of rank.
+ */
+function compareByProjection(a: PlayerData, b: PlayerData): number {
+  const aHasPpg = typeof a.fantasy_ppg === 'number' && a.fantasy_ppg > 0
+  const bHasPpg = typeof b.fantasy_ppg === 'number' && b.fantasy_ppg > 0
+  if (aHasPpg && bHasPpg) return b.fantasy_ppg! - a.fantasy_ppg!
+  if (aHasPpg !== bHasPpg) return aHasPpg ? -1 : 1
+  return (a.rank ?? 999) - (b.rank ?? 999)
 }
 
 export const buildLineup = (
@@ -441,13 +453,13 @@ export const buildLineup = (
       }
     })
   } else {
-    // Optimized mode: use filtered availablePlayers
-    const qbs = availablePlayers.filter((p) => p.position === 'QB').sort((a, b) => a.rank - b.rank)
-    const rbs = availablePlayers.filter((p) => p.position === 'RB').sort((a, b) => a.rank - b.rank)
-    const wrs = availablePlayers.filter((p) => p.position === 'WR').sort((a, b) => a.rank - b.rank)
-    const tes = availablePlayers.filter((p) => p.position === 'TE').sort((a, b) => a.rank - b.rank)
-    const flexEligible = [...rbs, ...wrs, ...tes].sort((a, b) => a.rank - b.rank)
-    const superFlexEligible = [...qbs, ...rbs, ...wrs, ...tes].sort((a, b) => a.rank - b.rank)
+    // Optimized mode: use filtered availablePlayers, ranked by projected points (rank as fallback)
+    const qbs = availablePlayers.filter((p) => p.position === 'QB').sort(compareByProjection)
+    const rbs = availablePlayers.filter((p) => p.position === 'RB').sort(compareByProjection)
+    const wrs = availablePlayers.filter((p) => p.position === 'WR').sort(compareByProjection)
+    const tes = availablePlayers.filter((p) => p.position === 'TE').sort(compareByProjection)
+    const flexEligible = [...rbs, ...wrs, ...tes].sort(compareByProjection)
+    const superFlexEligible = [...qbs, ...rbs, ...wrs, ...tes].sort(compareByProjection)
 
     for (let i = 0; i < (rosterPositions.QB || 0); i++) {
       if (qbs[i]) {
@@ -506,4 +518,313 @@ export const buildLineup = (
   })
 
   return { lineup, bench }
+}
+
+// ---------------------------------------------------------------------------
+// Audit: stat-management diagnostics (position depth, injury exposure, activity)
+// ---------------------------------------------------------------------------
+
+const AUDIT_POSITIONS = ['QB', 'RB', 'WR', 'TE'] as const
+const FLEX_ELIGIBLE = new Set(['RB', 'WR', 'TE'])
+
+export interface PositionDepthGap {
+  position: string
+  startersNeeded: number
+  rosteredCount: number
+  availableCount: number
+  healthScore: number // 0-100+; 100 = exactly enough available starters, no bench buffer
+  severity: 'critical' | 'thin' | 'healthy'
+}
+
+/**
+ * How many rostered/available players a team has at each position relative to how many
+ * that roster shape actually needs to start (direct slots + a fair share of FLEX/SUPER_FLEX).
+ */
+export const calculatePositionDepthGaps = (
+  players: PlayerData[],
+  rosterPositions: RosterPositions
+): PositionDepthGap[] => {
+  const flexShare = Math.ceil((rosterPositions.FLEX ?? 0) / FLEX_ELIGIBLE.size)
+  const superFlexShare = Math.ceil((rosterPositions.SUPER_FLEX ?? 0) / (AUDIT_POSITIONS.length))
+
+  return AUDIT_POSITIONS.map((position) => {
+    const directSlots = rosterPositions[position as keyof RosterPositions] ?? 0
+    const startersNeeded =
+      directSlots + (FLEX_ELIGIBLE.has(position) ? flexShare : 0) + superFlexShare
+
+    const atPosition = players.filter((p) => p.position === position)
+    const rosteredCount = atPosition.length
+    const availableCount = atPosition.filter(isPlayerAvailable).length
+
+    const healthScore =
+      startersNeeded > 0 ? Math.round((availableCount / startersNeeded) * 100) : 100
+
+    let severity: PositionDepthGap['severity'] = 'healthy'
+    if (availableCount < startersNeeded) severity = 'critical'
+    else if (availableCount <= startersNeeded) severity = 'thin'
+
+    return { position, startersNeeded, rosteredCount, availableCount, healthScore, severity }
+  })
+}
+
+export interface InjuryExposure {
+  injuredCount: number
+  injuredStarterCount: number
+  players: PlayerData[]
+  riskLevel: 'low' | 'moderate' | 'high'
+}
+
+const INJURY_STATUSES = new Set(['questionable', 'doubtful', 'out', 'ir'])
+
+function isInjuryFlagged(player: PlayerData): boolean {
+  const status = (player.injury_status || '').toLowerCase().trim()
+  return INJURY_STATUSES.has(status) || Boolean(player.injury_start_date)
+}
+
+/** Surfaces every rostered player carrying an injury designation, weighted by starter impact. */
+export const calculateInjuryExposure = (
+  players: PlayerData[],
+  currentStarters: string[]
+): InjuryExposure => {
+  const injuredPlayers = players.filter(isInjuryFlagged)
+  const starterSet = new Set(currentStarters)
+  const injuredStarterCount = injuredPlayers.filter((p) => starterSet.has(p.playerId)).length
+
+  let riskLevel: InjuryExposure['riskLevel'] = 'low'
+  if (injuredStarterCount >= 2) riskLevel = 'high'
+  else if (injuredStarterCount === 1) riskLevel = 'moderate'
+
+  return {
+    injuredCount: injuredPlayers.length,
+    injuredStarterCount,
+    players: injuredPlayers,
+    riskLevel,
+  }
+}
+
+export interface TransactionActivitySummary {
+  totalMoves: number
+  waiverClaims: number
+  trades: number
+  freeAgentAdds: number
+  last4WeeksMoves: number
+  activityLevel: 'inactive' | 'moderate' | 'active' | 'hyperactive'
+}
+
+/** Summarizes a team's roster-management activity from their completed transactions. */
+export const calculateTransactionActivity = (
+  transactions: SleeperTransaction[] | undefined,
+  currentWeek: number
+): TransactionActivitySummary => {
+  const tx = transactions ?? []
+  const waiverClaims = tx.filter((t) => t.type === 'waiver').length
+  const trades = tx.filter((t) => t.type === 'trade').length
+  const freeAgentAdds = tx.filter((t) => t.type === 'free_agent').length
+  const last4WeeksMoves = tx.filter((t) => t.leg > currentWeek - 4 && t.leg <= currentWeek).length
+
+  let activityLevel: TransactionActivitySummary['activityLevel'] = 'inactive'
+  if (last4WeeksMoves >= 6) activityLevel = 'hyperactive'
+  else if (last4WeeksMoves >= 3) activityLevel = 'active'
+  else if (last4WeeksMoves >= 1) activityLevel = 'moderate'
+
+  return {
+    totalMoves: tx.length,
+    waiverClaims,
+    trades,
+    freeAgentAdds,
+    last4WeeksMoves,
+    activityLevel,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Valuation: P/E-ratio-style price (KTC) vs earnings (production) scoring
+// ---------------------------------------------------------------------------
+
+function medianOf(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+export interface PositionalMedians {
+  medianKtc: number
+  medianFfpg: number
+}
+
+/** League-wide KTC value and fantasy PPG medians per position, for normalizing P/E ratios. */
+export const calculatePositionalMedians = (
+  players: PlayerData[]
+): Record<string, PositionalMedians> => {
+  const result: Record<string, PositionalMedians> = {}
+  for (const pos of AUDIT_POSITIONS) {
+    const atPos = players.filter((p) => p.position === pos)
+    const ktcValues = atPos
+      .map((p) => p.ktcValueSf)
+      .filter((v): v is number => typeof v === 'number' && v > 0)
+    const ffpgValues = atPos
+      .map((p) => p.fantasy_ppg)
+      .filter((v): v is number => typeof v === 'number' && v > 0)
+    result[pos] = { medianKtc: medianOf(ktcValues), medianFfpg: medianOf(ffpgValues) }
+  }
+  return result
+}
+
+/**
+ * Price/earnings ratio: (KTC value ÷ positional median KTC) ÷ (fantasy_ppg ÷ positional
+ * median fantasy_ppg). < 0.7 = undervalued (production exceeds price), > 1.5 = overvalued
+ * (paying for name value over output), ~1.0 = fair. Returns null when there's no production
+ * sample yet (rookies, injured all season) — those are speculative, not mispriced.
+ */
+export const calculatePERatio = (
+  player: PlayerData,
+  medians: Record<string, PositionalMedians>
+): number | null => {
+  const posMedians = medians[player.position]
+  if (!posMedians || posMedians.medianKtc <= 0 || posMedians.medianFfpg <= 0) return null
+  if (!player.ktcValueSf || !player.fantasy_ppg || player.fantasy_ppg <= 0) return null
+
+  const priceMultiple = player.ktcValueSf / posMedians.medianKtc
+  const earningsMultiple = player.fantasy_ppg / posMedians.medianFfpg
+  if (earningsMultiple <= 0) return null
+
+  return priceMultiple / earningsMultiple
+}
+
+// ---------------------------------------------------------------------------
+// Production vs. value: is this team's on-field output backed by its roster talent?
+// ---------------------------------------------------------------------------
+
+export interface ProductionVsValue {
+  productionRank: number // 1 = most points scored league-wide
+  valueRank: number // 1 = highest roster value (nowScore) league-wide
+  gap: number // productionRank - valueRank; positive = production trailing value
+  signal: 'underperforming' | 'overperforming' | 'aligned'
+}
+
+/**
+ * Compares a team's points-scored rank against its roster-value rank. A team can rank well
+ * on value (talented roster, per KTC) but rank poorly on production (points scored) —
+ * talent that isn't translating to the scoreboard — or the reverse (punching above its
+ * roster's weight). This is a different failure mode than the win/loss-based Pretender
+ * overlay in competitiveState.ts, which only looks at record vs. roster value.
+ */
+export const calculateProductionVsValue = (
+  rosterId: number,
+  teams: TeamData[],
+  placements: LeaguePlacements
+): ProductionVsValue | null => {
+  if (teams.length === 0) return null
+
+  const byPoints = [...teams].sort((a, b) => b.pointsFor - a.pointsFor)
+  const productionRank = byPoints.findIndex((t) => t.rosterId === rosterId) + 1
+
+  const byValue = [...teams].sort(
+    (a, b) =>
+      (placements.placements[b.rosterId]?.nowScore ?? 0) -
+      (placements.placements[a.rosterId]?.nowScore ?? 0)
+  )
+  const valueRank = byValue.findIndex((t) => t.rosterId === rosterId) + 1
+
+  if (productionRank === 0 || valueRank === 0) return null
+
+  const gap = productionRank - valueRank
+  const gapThreshold = Math.max(2, Math.ceil(teams.length / 4))
+
+  let signal: ProductionVsValue['signal'] = 'aligned'
+  if (gap >= gapThreshold) signal = 'underperforming'
+  else if (gap <= -gapThreshold) signal = 'overperforming'
+
+  return { productionRank, valueRank, gap, signal }
+}
+
+// ---------------------------------------------------------------------------
+// League activity feed: resolves raw transactions into named adds/drops
+// ---------------------------------------------------------------------------
+
+export interface ActivityFeedItem {
+  id: string
+  type: 'trade' | 'waiver' | 'free_agent'
+  timestamp: number
+  adds: { playerName: string; teamName: string }[]
+  drops: { playerName: string; teamName: string }[]
+}
+
+/** Resolves raw Sleeper transactions (player IDs, roster IDs) into a display-ready feed. */
+export const buildActivityFeed = (
+  transactions: SleeperTransaction[],
+  teams: TeamData[],
+  allPlayers: Record<string, any>
+): ActivityFeedItem[] => {
+  const teamNameFor = (rosterId: number) =>
+    teams.find((t) => t.rosterId === rosterId)?.teamName ?? 'Unknown Team'
+
+  const playerNameFor = (playerId: string) => {
+    const p = allPlayers[playerId]
+    if (!p) return playerId
+    return `${p.first_name ?? ''} ${p.last_name ?? ''}`.trim() || playerId
+  }
+
+  return transactions.map((tx) => ({
+    id: tx.transaction_id,
+    type: tx.type,
+    timestamp: tx.created,
+    adds: Object.entries(tx.adds ?? {}).map(([playerId, rosterId]) => ({
+      playerName: playerNameFor(playerId),
+      teamName: teamNameFor(rosterId),
+    })),
+    drops: Object.entries(tx.drops ?? {}).map(([playerId, rosterId]) => ({
+      playerName: playerNameFor(playerId),
+      teamName: teamNameFor(rosterId),
+    })),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Risk factor: composite of aged/declining production and injury exposure
+// ---------------------------------------------------------------------------
+
+export interface RiskFactor {
+  score: number // 0-100, higher = riskier
+  ageRiskScore: number // 0-100 — share of roster past its position's typical peak window
+  injuryRiskScore: number // 0-100 — current injury exposure blended with season durability
+  label: 'low' | 'moderate' | 'high'
+}
+
+const PEAK_AGE_END: Record<string, number> = { QB: 34, RB: 27, WR: 30, TE: 31 }
+
+/**
+ * Blends two independent risk signals into one team-level score: how much of the roster
+ * is past its position's typical productive age window (age risk), and how much on-field
+ * availability is already compromised — current injured starters plus games already missed
+ * relative to what should have been played by now (injury risk).
+ */
+export const calculateRiskFactor = (team: TeamData, currentWeek: number): RiskFactor => {
+  const relevant = team.players.filter((p) =>
+    (AUDIT_POSITIONS as readonly string[]).includes(p.position)
+  )
+
+  const aged = relevant.filter((p) => p.age)
+  const pastPeakCount = aged.filter((p) => p.age > (PEAK_AGE_END[p.position] ?? 30)).length
+  const ageRiskScore = aged.length > 0 ? Math.round((pastPeakCount / aged.length) * 100) : 0
+
+  const injuryExposure = calculateInjuryExposure(team.players, team.starters)
+  const currentInjuryRisk =
+    team.starters.length > 0
+      ? (injuryExposure.injuredStarterCount / team.starters.length) * 100
+      : 0
+
+  const expectedGames = Math.max(1, currentWeek - 1)
+  const trackable = relevant.filter((p) => typeof p.games_played === 'number')
+  const missedTimeCount = trackable.filter(
+    (p) => (p.games_played as number) < expectedGames * 0.7
+  ).length
+  const durabilityRisk = trackable.length > 0 ? (missedTimeCount / trackable.length) * 100 : 0
+
+  const injuryRiskScore = Math.round(currentInjuryRisk * 0.6 + durabilityRisk * 0.4)
+  const score = Math.round(ageRiskScore * 0.5 + injuryRiskScore * 0.5)
+  const label: RiskFactor['label'] = score >= 60 ? 'high' : score >= 35 ? 'moderate' : 'low'
+
+  return { score, ageRiskScore, injuryRiskScore, label }
 }


### PR DESCRIPTION
Unify the two competing team-tier systems onto the roster-value x age quadrant model (Juggernaut / Contender / Pretender / Fringe Team / Rebuilder), replacing the older grade+rank tier that could disagree with it on the same team. Placements are now computed once in the shell and threaded down rather than recomputed per component.

Add an Audit tab with stat-management diagnostics (position health scores, injury exposure, transaction activity, production-vs-value rank) and a state-driven action plan.

Turn Overview into a hub: needs-attention status strip, league-wide activity feed, and trending adds -- the latter two from data that was already fetched but never surfaced.

Port two analytics ideas from the sleeper-sdk project: P/E-ratio valuation (KTC price vs fantasy-points production, normalized against positional medians) now drives Trade Intelligence buy/sell signals, and production-rank vs value-rank flags rosters whose talent isn't translating to points.

Also fixes a real bug: Sleeper's roster_positions is a flat slot array, but it was being assigned to a field typed as a position->count map. Added countRosterPositions() to tally it correctly.