### PR TITLE
Surface upcoming classes on the prospect board, order board sections …

### DIFF
--- a/firstballot/components/prospect-board/player-card.tsx
+++ b/firstballot/components/prospect-board/player-card.tsx
@@ -24,8 +24,11 @@ export function PlayerCard({ player, index }: PlayerCardProps) {
       whileHover={{ y: -4, transition: { duration: 0.2 } }}
       className="group relative bg-card rounded-lg overflow-hidden border border-border hover:border-primary/50 transition-colors duration-300"
     >
-      {/* Tier Badge */}
-      <div className="absolute top-3 right-3 z-10">
+      {/* Positional rank + grade tier */}
+      <div className="absolute top-3 right-3 z-10 flex items-center gap-1.5">
+        <span className="px-2 py-1 text-[10px] font-bold uppercase tracking-wider rounded border bg-secondary text-muted-foreground border-border">
+          {player.positionRank}
+        </span>
         <span
           className={cn(
             'px-2 py-1 text-[10px] font-bold uppercase tracking-wider rounded border',

--- a/firstballot/components/prospect-board/rankings-grid.tsx
+++ b/firstballot/components/prospect-board/rankings-grid.tsx
@@ -9,6 +9,27 @@ import { cn } from '@/lib/utils'
 
 type FilterTier = 'all' | 'Elite' | 'Blue Chip' | 'Starter' | 'Rotational' | 'Depth' | 'Longshot'
 
+/** Class filter: every undrafted class, one specific class, or the whole archive. */
+type YearFilter = number | 'all' | 'upcoming'
+
+/** Classes at or after this year have not been drafted yet. */
+const FIRST_UPCOMING_CLASS = 2027
+
+const TIER_ORDER: Exclude<FilterTier, 'all'>[] = [
+  'Elite',
+  'Blue Chip',
+  'Starter',
+  'Rotational',
+  'Depth',
+  'Longshot',
+]
+
+function matchesYear(year: number | null, filter: YearFilter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'upcoming') return (year ?? 0) >= FIRST_UPCOMING_CLASS
+  return year === filter
+}
+
 const positions: { key: Position; label: string }[] = [
   { key: 'QB', label: 'QB' },
   { key: 'RB', label: 'RB' },
@@ -26,7 +47,10 @@ const EMPTY_PLAYERS: Record<Position, Player[]> = {
 export function RankingsGrid() {
   const PAGE_SIZE = 30
   const [position, setPosition] = useState<Position>('QB')
-  const [selectedYear, setSelectedYear] = useState<number | 'all'>('all')
+  // Default to the undrafted classes. Sorting is by grade across every class,
+  // so on 'all' the 2027/2028 prospects sit ~50-80 deep behind a decade of
+  // drafted players and are effectively invisible.
+  const [selectedYear, setSelectedYear] = useState<YearFilter>('upcoming')
   const [filter, setFilter] = useState<FilterTier>('all')
   const [sortBy, setSortBy] = useState<'rank' | 'grade' | 'physical' | 'production'>('rank')
   const [isPending, startTransition] = useTransition()
@@ -35,10 +59,9 @@ export function RankingsGrid() {
 
   const handlePositionChange = (newPosition: Position) => {
     startTransition(() => {
+      // Class and tier selections carry across positions — resetting them threw
+      // away the filter the user had just set.
       setPosition(newPosition)
-      setSelectedYear('all')
-      setFilter('all')
-      setSortBy('rank')
       setVisibleCount(PAGE_SIZE)
     })
   }
@@ -47,9 +70,10 @@ export function RankingsGrid() {
   const years = Array.from(
     new Set(players.map((p) => p.year).filter((year): year is number => year !== null))
   ).sort((a, b) => b - a)
+  const hasUpcoming = years.some((year) => year >= FIRST_UPCOMING_CLASS)
 
   const filteredPlayers = players
-    .filter((p) => selectedYear === 'all' || p.year === selectedYear)
+    .filter((p) => matchesYear(p.year, selectedYear))
     .filter((p) => filter === 'all' || p.tier === filter)
     .sort((a, b) => {
       if (sortBy === 'rank') {
@@ -69,25 +93,26 @@ export function RankingsGrid() {
       rank: player.rank,
     }))
 
-  const yearFilteredPlayers = players.filter(
-    (p) => selectedYear === 'all' || p.year === selectedYear
-  )
+  const yearFilteredPlayers = players.filter((p) => matchesYear(p.year, selectedYear))
   const visiblePlayers = filteredPlayers.slice(0, visibleCount)
 
-  const tierCounts = {
+  const tierCounts: Record<FilterTier, number> = {
     all: yearFilteredPlayers.length,
-    Elite: yearFilteredPlayers.filter((p) => p.tier === 'Elite').length,
-    'Blue Chip': yearFilteredPlayers.filter((p) => p.tier === 'Blue Chip').length,
-    Starter: yearFilteredPlayers.filter((p) => p.tier === 'Starter').length,
-    Rotational: yearFilteredPlayers.filter((p) => p.tier === 'Rotational').length,
-    Depth: yearFilteredPlayers.filter((p) => p.tier === 'Depth').length,
-    Longshot: yearFilteredPlayers.filter((p) => p.tier === 'Longshot').length,
+    Elite: 0,
+    'Blue Chip': 0,
+    Starter: 0,
+    Rotational: 0,
+    Depth: 0,
+    Longshot: 0,
+  }
+  for (const player of yearFilteredPlayers) {
+    if (player.tier in tierCounts && player.tier !== 'all') {
+      tierCounts[player.tier as FilterTier] += 1
+    }
   }
   const availableTiers: FilterTier[] = [
     'all',
-    ...Object.entries(tierCounts)
-      .filter(([tier, count]) => tier !== 'all' && count > 0)
-      .map(([tier]) => tier as FilterTier),
+    ...TIER_ORDER.filter((tier) => tierCounts[tier] > 0),
   ]
 
   return (
@@ -99,7 +124,9 @@ export function RankingsGrid() {
           <div className="text-sm text-muted-foreground">
             Showing {visiblePlayers.length} of {filteredPlayers.length} prospect
             {filteredPlayers.length !== 1 ? 's' : ''}
-            {selectedYear !== 'all' && ` from ${selectedYear}`}
+            {selectedYear === 'upcoming'
+              ? ` from ${FIRST_UPCOMING_CLASS}+`
+              : selectedYear !== 'all' && ` from ${selectedYear}`}
             {filter !== 'all' && ` (${filter})`}
           </div>
         )}
@@ -129,11 +156,27 @@ export function RankingsGrid() {
             <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium mr-0.5">
               Class
             </span>
-            <button
+            {hasUpcoming && (
+              <button
                 onClick={() => {
-                  setSelectedYear('all')
+                  setSelectedYear('upcoming')
                   setVisibleCount(PAGE_SIZE)
                 }}
+                className={cn(
+                  'h-7 px-2.5 text-[11px] font-mono rounded transition-colors',
+                  selectedYear === 'upcoming'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-secondary/80 text-muted-foreground hover:text-foreground hover:bg-secondary'
+                )}
+              >
+                UPCOMING
+              </button>
+            )}
+            <button
+              onClick={() => {
+                setSelectedYear('all')
+                setVisibleCount(PAGE_SIZE)
+              }}
               className={cn(
                 'h-7 px-2.5 text-[11px] font-mono rounded transition-colors',
                 selectedYear === 'all'

--- a/firstballot/components/rankings/RankingsView.tsx
+++ b/firstballot/components/rankings/RankingsView.tsx
@@ -11,9 +11,17 @@ import { SkeletonGrid } from '@/components/prospect-board/player-skeleton'
 import type { Player, Position } from '@/lib/players'
 import type { PlayerRanking } from '@/types/rankings'
 
-function normalizeTier(grade: number, position: string, posRank: number): string {
+/**
+ * These rankings come from `dynasty_player_tiers`, which has no `grade_tier`
+ * column, so derive one using the same vocabulary `dynasty_prospects` stores.
+ */
+function normalizeTier(grade: number): string {
   if (grade >= 90) return 'Elite'
-  return `${position}${posRank}`
+  if (grade >= 85) return 'Blue Chip'
+  if (grade >= 80) return 'Starter'
+  if (grade >= 75) return 'Rotational'
+  if (grade >= 70) return 'Depth'
+  return 'Longshot'
 }
 
 function toCardPosition(position: string): Position {
@@ -86,7 +94,8 @@ export function RankingsView() {
         position,
         school: `${player.team} • Age ${player.age}`,
         espnId: player.espn_id ? Number(player.espn_id) : null,
-        tier: normalizeTier(grade, position, posRank),
+        tier: normalizeTier(grade),
+        positionRank: `${position}${posRank}`,
         grade,
         height: '',
         weight: null,

--- a/firstballot/components/scouting/DraftBoardTab.tsx
+++ b/firstballot/components/scouting/DraftBoardTab.tsx
@@ -314,7 +314,8 @@ export function DraftBoardTab({
       grouped.get(year)!.push(p)
     }
     return Array.from(grouped.entries())
-      .sort((a, b) => b[0] - a[0])
+      // Nearest class first — 2027 drafts before 2028, so it leads the board.
+      .sort((a, b) => a[0] - b[0])
       .map(([year, prospects]) => ({
         year,
         // Keep user-defined drag order within each class section.

--- a/firstballot/lib/players.ts
+++ b/firstballot/lib/players.ts
@@ -42,7 +42,10 @@ export interface Player {
   position: Position
   school: string
   espnId: number | null
+  /** Scouting grade tier from the database — the facet the tier filter uses. */
   tier: string
+  /** Positional-rank badge shown on the card, e.g. "WR3". */
+  positionRank: string
   grade: number
   height: string
   weight: number | null
@@ -156,6 +159,7 @@ function normalize(raw: RawProspect): Player {
     school: raw.school || 'TBD',
     espnId: raw.espn_id,
     tier: raw.grade_tier || 'Depth',
+    positionRank: `${raw.position}${raw.rank}`,
     grade: raw.overall_grade || 0,
     height: formatHeight(raw.height),
     weight: raw.weight ? Math.round(raw.weight) : null,
@@ -186,15 +190,12 @@ export async function fetchAllProspects(): Promise<Record<Position, Player[]>> {
       .sort((a, b) => (b.overall_grade || 0) - (a.overall_grade || 0))
     result[pos] = filtered.map((raw, index) => {
       const normalized = normalize(raw)
+      // Rank reflects position within this grade-sorted list, across all classes.
       const positionalRank = index + 1
-      const computedTier =
-        (normalized.grade || 0) >= 90 ? 'Elite' : `${normalized.position}${positionalRank}`
       return {
         ...normalized,
-        // Ensure rank reflects positional order within this list
         rank: positionalRank,
-        // Override tier based on grade/positional convention
-        tier: computedTier,
+        positionRank: `${pos}${positionalRank}`,
       }
     })
   }


### PR DESCRIPTION
…2027 first

/prospect-board sorts by grade across every class, so the newly imported 2027/2028 prospects sat 47-78 deep behind a decade of drafted players — the first 2028 WR was on the third "Load 30 More" page. Added an UPCOMING class filter (2027+) and made it the default; ALL and the individual years are still there. Switching position no longer resets the class and tier filters, which threw away the selection the user had just made.

The tier filter only ever offered "All" and "Elite" because fetchAllProspects overwrote the database `grade_tier` with a positional label ("QB1"), so the Blue Chip / Starter / Rotational / Depth / Longshot counts were always zero. Player now carries `tier` (the real grade tier, used by the filter) and `positionRank` (the card badge) separately, and the card shows both.

Draft board sections were ordered newest-first, putting 2028 above 2027. The nearest class drafts first, so it now leads.